### PR TITLE
Do not include the trailing NULL from the C-String in the SDP service-name

### DIFF
--- a/btif/src/btif_sock_sdp.c
+++ b/btif/src/btif_sock_sdp.c
@@ -137,7 +137,7 @@ static bool create_base_record(const uint32_t sdp_handle, const char *name,
   if (name[0] != '\0') {
     stage = "service_name";
     if (!SDP_AddAttribute(sdp_handle, ATTR_ID_SERVICE_NAME,
-                          TEXT_STR_DESC_TYPE, (uint32_t)(strlen(name) + 1),
+                          TEXT_STR_DESC_TYPE, (uint32_t)(strlen(name)),
                           (uint8_t *)name))
       goto error;
   }


### PR DESCRIPTION
The Bluedroid stack uses a C string with terminating NULL char as a service name. Since in BT, strings are TLV encoded (type, length, value), this doesn't make sense.
Checked against Linux BlueZ, which does not include this extra null character.
Simple fix is to copy the string without the trailing NULL by removing the "+1" after the strlen call when passing the string as uint8_t array to the lower level functions.

The current behaviour keeps some older devices from being able to connect to an Android providing a Serial Port profile due to having the wrong service name (that is, including a NULL at the end instead of the correct string).