### PR TITLE
Fix LE disconnecting right after pairing

### DIFF
--- a/stack/l2cap/l2c_utils.c
+++ b/stack/l2cap/l2c_utils.c
@@ -1753,6 +1753,12 @@ void l2cu_release_ccb (tL2C_CCB *p_ccb)
     {
         if (!p_lcb->ccb_queue.p_first_ccb)
         {
+            // Closing a security channel on LE device should not start connection
+            // timeout
+            if (p_lcb->transport == BT_TRANSPORT_LE &&
+                p_ccb->local_cid == L2CAP_SMP_CID)
+                return;
+            
             l2cu_no_dynamic_ccbs (p_lcb);
         }
         else


### PR DESCRIPTION
Please merge this, hopefully it fixes the incoming BT connections. Credit goes to: https://android-review.googlesource.com/#/c/382152/

When a device connect to android over LE, the default policy is to keep this connection. If any app "claims" this connnection, and then stop using it, we'll disconnect from the device after a short timeout. If pairing is triggered to such device, that is connected but not used by any app, it will cause disconnect after the pairing is finished. This is because using SMP over fixed LE L2CAP channel is conseidered as connecting, using, and disconnecting a channel by the stack. This is obvious logic error - using fixed channels should not require "connecting" to them. As a temporary workaround, do not trigger a timeout when a fixed SMP channel is closed over LE. For LE only devices, this means they will stay connected after the pairing until some app starts using them or they disconnect. For dual mode devices, Classic connection will be established and SDP will be performed. The classic connection will be disconnected if no app will use it, and the LE connection to the device will stay up.