### PR TITLE
Add support to force disable enhanced sco commands

### DIFF
--- a/device/src/controller.cc
+++ b/device/src/controller.cc
@@ -22,6 +22,7 @@
 
 #include <base/logging.h>
 
+#include "bt_target.h"
 #include "bt_types.h"
 #include "btcore/include/event_mask.h"
 #include "btcore/include/module.h"
@@ -129,6 +130,9 @@ static future_t* start_up(void) {
       AWAIT_COMMAND(packet_factory->make_read_local_supported_commands());
   packet_parser->parse_read_local_supported_commands_response(
       response, supported_commands, HCI_SUPPORTED_COMMANDS_ARRAY_SIZE);
+#if (BTM_SCO_ENHANCED_SYNC_ENABLED == FALSE)
+  supported_commands[29] &= ~0x08;
+#endif
 
   // Read page 0 of the controller features next
   uint8_t page_number = 0;

--- a/internal_include/bt_target.h
+++ b/internal_include/bt_target.h
@@ -286,6 +286,12 @@
 #define BTM_DISC_DURING_RS TRUE
 #endif
 
+/*  This is used to work around a controller bug that report supporting
+ *  enhanced synchronous commands */
+#ifndef BTM_SCO_ENHANCED_SYNC_ENABLED
+#define BTM_SCO_ENHANCED_SYNC_ENABLED TRUE
+#endif
+
 /**************************
  * Initial SCO TX credit
  ************************/


### PR DESCRIPTION
Change-Id: I04c73d723d50c2f619102e1904b05937a77d0103
(cherry picked from commit a7fb51fdb48cefc47f32b1e6b1a1f9bb71e7d953)
Need to add this with fix bluetooth calling issue. 